### PR TITLE
g3: Kill mm-parser

### DIFF
--- a/proprietary-files.txt
+++ b/proprietary-files.txt
@@ -167,12 +167,8 @@ etc/firmware/a330_pfp.fw
 etc/firmware/a330_pm4.fw
 
 # Media
-vendor/lib/libDivxDrm.so
-vendor/lib/libExtendedExtractor.so
 -vendor/lib/libHevcSwDecoder.so
 vendor/lib/libI420colorconvert.so
-vendor/lib/libmmosal.so
-vendor/lib/libmmparser.so
 vendor/lib/libmm-color-convertor.so
 vendor/lib/libOmxAacDec.so
 vendor/lib/libOmxAmrwbplusDec.so


### PR DESCRIPTION
 * Qualcomm caused hell-on-earth with libavenhancements- an
   apparently well-intentioned effort to minimize the amount of
   change in f/av which has backfired. In order to use this
   library, an OEM must not change *anything* *anywhere* in f/av
   to maintain ABI exactness. And that ABI exactness is different
   per SoC branch and constantly in motion. Best of all, the
   base classes are monkey patched with a proprietary library which also
   is different per SoC branch and much exactly match the f/av
   code. And if you get the ABI right, then your customizations
   stop working because they've been hijacked by overloading. The whole
   message bus is hijacked, and you're wasting your time.

 * Now that FFMPEG can talk to all the hardware codecs, there is no
   reason to tolerate this. Our stack has more features, more codec
   support, and it's open source all the way.

 * I love Qualcomm's SoCs, but come on guys.. I expect every OEM
   will complain about this AV shit then proceed to gut it as I am doing.

Change-Id: I31f9f4076c498a4ed016bec4c7352dad0f62c72e