### PR TITLE
mixer_paths_qcwn: fix speaker-dmic-endfire

### DIFF
--- a/configs/audio/mixer_paths_qcwcn.xml
+++ b/configs/audio/mixer_paths_qcwcn.xml
@@ -1331,10 +1331,14 @@
         <ctl name="AIF1_CAP Mixer SLIM TX8" value="1" />
         <ctl name="SLIM TX7 MUX" value="DEC4" />
         <ctl name="DEC4 MUX" value="ADC3" />
-        <ctl name="SLIM TX8 MUX" value="DEC6" />
-        <ctl name="DEC6 MUX" value="ADC1" />
+        <ctl name="SLIM TX8 MUX" value="DEC2" />
+        <ctl name="DEC2 MUX" value="ADC5" />
         <ctl name="SLIM_0_TX Channels" value="Two" />
         <ctl name="IIR1 INP1 MUX" value="DEC4" />
+        <ctl name="ADC3 Volume" value="12" />
+        <ctl name="DEC4 Volume" value="60" />
+        <ctl name="ADC5 Volume" value="12" />
+        <ctl name="DEC2 Volume" value="60" />
     </path>
 
     <path name="dmic-endfire">


### PR DESCRIPTION
* kangbang from stock, fixes speakerphone

Change-Id: Id1657d89ff1f080cbdb1c22978c7f8cc8a35d0dd