### PR TITLE
g3: add audio related property overrides

### DIFF
--- a/system_prop.mk
+++ b/system_prop.mk
@@ -1,5 +1,7 @@
 # Audio
 PRODUCT_PROPERTY_OVERRIDES += \
+    af.fast_track_multiplier=1 \
+    audio_hal.period_size=192 \
     media.aac_51_output_enabled=true \
     use.voice.path.for.pcm.voip=true
 


### PR DESCRIPTION
override audio_hal.period_size and af.fast_track_multiplier
properties to optimize the playback latency.

Change-Id: I9e9ccf87dbc1697b84354a388e4abd8868300251